### PR TITLE
timeout 0 support breaks even example code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/nadoo/ipset
+module github.com/dpapchenkov/ipset
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dpapchenkov/ipset
+module github.com/nadoo/ipset
 
 go 1.18

--- a/internal/netlink/netlink.go
+++ b/internal/netlink/netlink.go
@@ -69,7 +69,7 @@ type NetLink struct {
 
 // NullableUint32 for Options
 type NullableUint32 struct {
-	Value int
+	Value uint32
 	Valid bool
 }
 

--- a/internal/netlink/netlink.go
+++ b/internal/netlink/netlink.go
@@ -67,10 +67,16 @@ type NetLink struct {
 	lsa syscall.SockaddrNetlink
 }
 
+// NullableUint32 for Options
+type NullableUint32 struct {
+	Value int
+	Valid bool
+}
+
 // Options for netlink.
 type Options struct {
 	IPv6    bool
-	Timeout uint32
+	Timeout NullableUint32
 	Excl    bool
 }
 
@@ -126,8 +132,8 @@ func (nl *NetLink) CreateSet(setName string, opts ...Option) error {
 	req.AddData(NewRtAttr(IPSET_ATTR_FAMILY, Uint8Attr(family)))
 
 	attrData := NewRtAttr(IPSET_ATTR_DATA|NLA_F_NESTED, nil)
-	if option.Timeout != 0 {
-		attrData.AddChild(&Uint32Attribute{Type: IPSET_ATTR_TIMEOUT | NLA_F_NET_BYTEORDER, Value: option.Timeout})
+	if option.Timeout.Valid {
+		attrData.AddChild(&Uint32Attribute{Type: IPSET_ATTR_TIMEOUT | NLA_F_NET_BYTEORDER, Value: option.Timeout.Value})
 	}
 	req.AddData(attrData)
 
@@ -189,8 +195,8 @@ func (nl *NetLink) HandleAddr(cmd int, setName string, ip netip.Addr, cidr netip
 
 	attrData := NewRtAttr(IPSET_ATTR_DATA|NLA_F_NESTED, nil)
 
-	if option.Timeout >= 0 {
-		attrData.AddChild(&Uint32Attribute{Type: IPSET_ATTR_TIMEOUT | NLA_F_NET_BYTEORDER, Value: option.Timeout})
+	if option.Timeout.Valid {
+		attrData.AddChild(&Uint32Attribute{Type: IPSET_ATTR_TIMEOUT | NLA_F_NET_BYTEORDER, Value: option.Timeout.Value})
 	}
 
 	attrIP := NewRtAttrChild(attrData, IPSET_ATTR_IP|NLA_F_NESTED, nil)

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -3,7 +3,7 @@ package ipset
 import (
 	"net/netip"
 
-	"github.com/nadoo/ipset/internal/netlink"
+	"github.com/dpapchenkov/ipset/internal/netlink"
 )
 
 var nl *netlink.NetLink
@@ -15,7 +15,9 @@ type Option = netlink.Option
 func OptIPv6() Option { return func(opts *netlink.Options) { opts.IPv6 = true } }
 
 // OptTimeout sets `timeout xx` parameter to operations.
-func OptTimeout(timeout uint32) Option { return func(opts *netlink.Options) { opts.Timeout = timeout } }
+func OptTimeout(timeout uint32) Option {
+	return func(opts *netlink.Options) { opts.Timeout = netlink.NullableUint32{Value: timeout, Valid: true} }
+}
 
 func OptExcl() Option { return func(opts *netlink.Options) { opts.Excl = true } }
 

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -3,7 +3,7 @@ package ipset
 import (
 	"net/netip"
 
-	"github.com/dpapchenkov/ipset/internal/netlink"
+	"github.com/nadoo/ipset/internal/netlink"
 )
 
 var nl *netlink.NetLink


### PR DESCRIPTION
Hello. After 08468a7 changes (timeout 0 support), timeout attribute assigned to every rule. I've fixed this.